### PR TITLE
Fixed SendGrid Developers Location + Capitalization

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -65,8 +65,8 @@
 		},
 		{
 			"shortcuts": ["sendgrid", "sg"],
-			"name": "Sendgrid",
-			"url": "http://sendgrid.com/developer"
+			"name": "SendGrid",
+			"url": "http://sendgrid.com/developers"
 		},
 		{
 			"shortcuts": ["pebble"],


### PR DESCRIPTION
The link to the dev center was actually set to our admin, I fixed it and made the capitalization correct to brand (as GitHub and others have).
