### PR TITLE
Make site links easier to tap on mobile

### DIFF
--- a/scss/css/devcenter.scss
+++ b/scss/css/devcenter.scss
@@ -20,6 +20,10 @@
 	height: 44px;
 	line-height: 44px;
 
+	> a {
+		display: block;
+	}
+
 	.shortcuts {
 		font-size: 13px;
 		color: $secondary-color;


### PR DESCRIPTION
Just `display: block;`s the site links. 
