### PR TITLE
Use a click handler to allow clicking on a site instead of display: block

### DIFF
--- a/scss/css/devcenter.scss
+++ b/scss/css/devcenter.scss
@@ -20,10 +20,6 @@
 	height: 44px;
 	line-height: 44px;
 
-	> a {
-		display: block;
-	}
-
 	.shortcuts {
 		font-size: 13px;
 		color: $secondary-color;

--- a/views/layout.hbs
+++ b/views/layout.hbs
@@ -101,6 +101,12 @@
 				$("#search").val(existingSearch);
 				performSearch(existingSearch);
 			}
+
+			$('.site').click(function(e) {
+				if(!$(e.target).is('a') && $(this).find('a').length > 0) {
+					document.location = $(this).find('a').attr('href');
+				}
+			});
 		});
 	</script>
 


### PR DESCRIPTION
This allows clicks on the block to trigger the link while still allowing shortcuts to be viewed. Tested by pasting the jQuery stuff into the Web Inspector console and turning off the .site > a display rule (Safari 7). Clicking both the link and the block work and option showed the shortcuts next to the title instead of underneath the title below.
