### PR TITLE
Add “osx” shortcut for Mac Dev Center.

### DIFF
--- a/sites/Mac Dev Center.json
+++ b/sites/Mac Dev Center.json
@@ -1,6 +1,7 @@
 {
 	"shortcuts": [
-		"mac"
+		"mac",
+		"osx"
 	],
 	"name": "Mac Dev Center",
 	"sortKey": "Apple Mac",


### PR DESCRIPTION
I always types _OSX_ first before remembering that in this instance it’s still referred to as _Mac_. So to save my sanity and a few keystrokes this adds `osx` as a shortcut for the Mac Dev Center :smile_cat:
