### PR TITLE
Add Designer News API to list of sites

### DIFF
--- a/sites/Designer News.json
+++ b/sites/Designer News.json
@@ -1,0 +1,9 @@
+{
+        "shortcuts": [
+                "designernews",
+                "dn"
+        ],
+        "name": "Designer News API",
+        "url": "http://developers.news.layervault.com/",
+        "id": "designernews"
+}


### PR DESCRIPTION
**Changelog:**
- Added Designer News to the list of sites with shortcuts `dn` and `designernews`.
